### PR TITLE
投稿機能の非同期機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,6 @@
+$(function(){
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+  })
+})

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -33,7 +33,6 @@ $(function(){
   .done(function(data){
     var html = buildHTML(data);
     $('.main__content').append(html);
-    $('.form__box__message').val('');
     $('form')[0].reset();
     $("html,body").animate({scrollTop: $(document).height()
     },1500);

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,27 @@
 $(function(){
+  function buildHTML(message){
+    var image = ""
+    message.image ? image = `<img src="${message.image}">` : image =""
+    var html = `<div class="main__content__message__upper-box">
+                  <div class="main__content__message__upper-box__user-name">
+                    ${message.user_name}
+                  </div> 
+                  <div class="main__content__message__upper-box__time">
+                    ${message.created_at}
+                  </div>
+                </div>
+                <div class="main__content__message__text-box">
+                  <p class="main__content__message__text-box__text">
+                    ${message.content}
+                  </p>
+                  ${image}
+                </div>`;
+    return html;
+  }
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
-    var url = $(this).attr('action')
+    var url = $(this).attr('action');
     $.ajax({
       url: url,
       type: "POST",
@@ -11,5 +30,18 @@ $(function(){
       processData: false,
       contentType: false
   })
+  .done(function(data){
+    var html = buildHTML(data);
+    $('.main__content').append(html);
+    $('.form__box__message').val('');
+    $('form')[0].reset();
+    scroll();
+  })
+  .fail(function(){
+    alert('error');
+  })
+  .always(() => {
+    $(".form__submit").removeAttr("disabled");
+  });
  })
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,5 +2,14 @@ $(function(){
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
   })
+ })
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,7 +35,9 @@ $(function(){
     $('.main__content').append(html);
     $('.form__box__message').val('');
     $('form')[0].reset();
-    scroll();
+    $("html,body").animate({scrollTop: $(document).height()
+    },1500);
+
   })
   .fail(function(){
     alert('error');

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,7 +11,7 @@ class MessagesController < ApplicationController
     if @message.save
       respond_to do |format|
         format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
-        format.json { render json: @message}
+        format.json
       end
     else
       @messages = @group.messages.includes(:user)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json { render json: @message}
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.content  @message.content
 json.image  @message.image.url
-json.created_at @message.created_at
+json.created_at @message.created_at.to_s
 json.user_name  @message.user.name
 json.group_id  @message.group.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.text  @message.text
-json.image  @message.image
-json.user_id  @message.user.id
+json.content  @message.content
+json.image  @message.image.url
+json.created_at @message.created_at
+json.user_name  @message.user.name
 json.group_id  @message.group.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.text  @message.text
+json.image  @message.image
+json.user_id  @message.user.id
+json.group_id  @message.group.id

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,5 @@
+Time::DATE_FORMATS[:default] = '%Y/%m/%d %H:%M'
+Time::DATE_FORMATS[:datetime] = '%Y/%m/%d %H:%M'
+Time::DATE_FORMATS[:date] = '%Y/%m/%d'
+Time::DATE_FORMATS[:time] = '%H:%M:%S'
+Date::DATE_FORMATS[:default] = '%Y/%m/%d'


### PR DESCRIPTION
#WHAT
・jsファイルを作成→フォームが送信されたら、イベントが発火。その際にAjaxよりmessages#createが動くようにプログラム。そのmessages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
・jbuilderのファイルを作成して、作成したメッセージをJSON形式でjsファイルに返す。その返ってきたJSONをdoneメソッドで受取り、HTMLを作成する。作成したHTMLをメッセージ画面の一番下に追加する。HTMLを追加した分、メッセージ画面を下にスクロールする。
・連続で送信ボタンを押せるようにした。非同期に失敗した場合の処理も書いた。

#WHY
再読込しなくても投稿が自動で表示されるようにするため。